### PR TITLE
Recognise separator in colors

### DIFF
--- a/syntax/i3.vim
+++ b/syntax/i3.vim
@@ -64,7 +64,7 @@ syn match i3ColorLast "#[0-9a-fA-F]\{6\}" contained nextgroup=i3Error skipwhite
 syn match i3Color2nd "#[0-9a-fA-F]\{6\}" contained nextgroup=i3ColorLast skipwhite
 syn match i3Color1st "#[0-9a-fA-F]\{6\}" contained nextgroup=i3Color2nd skipwhite
 
-syn match i3ColorDef1 "client\.background\|statusline\|background" nextgroup=i3ColorLast skipwhite
+syn match i3ColorDef1 "client\.background\|statusline\|background\|separator" nextgroup=i3ColorLast skipwhite
 syn match i3ColorDef3 "client\.\(focused_inactive\|focused\|unfocused\|urgent\)\|inactive_workspace\|urgent_workspace\|focused_workspace\|active_workspace" nextgroup=i3Color1st skipwhite
 
 highlight link i3ChainDelimiter       Operator


### PR DESCRIPTION
You can define a colour of vertical bar in i3bar using 'separator' key.
